### PR TITLE
KAFKA-12495: Improve rebalance allocation algorithm

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -245,10 +245,9 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         ConnectorsAndTasks deleted = diff(previousAssignment, configured);
         log.debug("Deleted assignments: {}", deleted);
 
-        // Derived set: The set of remaining active connectors-and-tasks is a derived set from the
-        // set difference of active - deleted
-        ConnectorsAndTasks remainingActive = diff(activeAssignments, deleted);
-        log.debug("Remaining (excluding deleted) active assignments: {}", remainingActive);
+        // The connectors and tasks that are currently running on more than one worker each
+        ConnectorsAndTasks duplicated = duplicatedAssignments(memberAssignments);
+        log.trace("Duplicated assignments: {}", duplicated);
 
         // Derived set: The set of lost or unaccounted connectors-and-tasks is a derived set from
         // the set difference of previous - active - deleted
@@ -257,51 +256,47 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
         // Derived set: The set of new connectors-and-tasks is a derived set from the set
         // difference of configured - previous - active
-        ConnectorsAndTasks newSubmissions = diff(configured, previousAssignment, activeAssignments);
-        log.debug("New assignments: {}", newSubmissions);
-
-        // A collection of the complete assignment
-        List<WorkerLoad> completeWorkerAssignment = workerAssignment(memberAssignments, ConnectorsAndTasks.EMPTY);
-        log.debug("Complete (ignoring deletions) worker assignments: {}", completeWorkerAssignment);
-
-        // Per worker connector assignments without removing deleted connectors yet
-        Map<String, Collection<String>> connectorAssignments =
-                completeWorkerAssignment.stream().collect(Collectors.toMap(WorkerLoad::worker, WorkerLoad::connectors));
-        log.debug("Complete (ignoring deletions) connector assignments: {}", connectorAssignments);
-
-        // Per worker task assignments without removing deleted connectors yet
-        Map<String, Collection<ConnectorTaskId>> taskAssignments =
-                completeWorkerAssignment.stream().collect(Collectors.toMap(WorkerLoad::worker, WorkerLoad::tasks));
-        log.debug("Complete (ignoring deletions) task assignments: {}", taskAssignments);
+        ConnectorsAndTasks created = diff(configured, previousAssignment, activeAssignments);
+        log.debug("New assignments: {}", created);
 
         // A collection of the current assignment excluding the connectors-and-tasks to be deleted
         List<WorkerLoad> currentWorkerAssignment = workerAssignment(memberAssignments, deleted);
 
-        Map<String, ConnectorsAndTasks> toRevoke = computeDeleted(deleted, connectorAssignments, taskAssignments);
-        log.debug("Connector and task to delete assignments: {}", toRevoke);
+        Map<String, ConnectorsAndTasks.Builder> toRevoke = new HashMap<>();
+
+        Map<String, ConnectorsAndTasks> deletedAndRevoked = intersection(deleted, memberAssignments);
+        log.debug("Deleted connectors and tasks to revoke from each worker: {}", deletedAndRevoked);
+        addAll(toRevoke, deletedAndRevoked);
 
         // Revoking redundant connectors/tasks if the workers have duplicate assignments
-        toRevoke.putAll(computeDuplicatedAssignments(memberAssignments, connectorAssignments, taskAssignments));
-        log.debug("Connector and task to revoke assignments (include duplicated assignments): {}", toRevoke);
+        Map<String, ConnectorsAndTasks> duplicatedAndRevoked = intersection(duplicated, memberAssignments);
+        log.debug("Duplicated connectors and tasks to revoke from each worker: {}", duplicatedAndRevoked);
+        addAll(toRevoke, duplicatedAndRevoked);
 
-        // Recompute the complete assignment excluding the deleted connectors-and-tasks
-        completeWorkerAssignment = workerAssignment(memberAssignments, deleted);
-        connectorAssignments =
-                completeWorkerAssignment.stream().collect(Collectors.toMap(WorkerLoad::worker, WorkerLoad::connectors));
-        taskAssignments =
-                completeWorkerAssignment.stream().collect(Collectors.toMap(WorkerLoad::worker, WorkerLoad::tasks));
+        // Compute the assignment that will be applied across the cluster after this round of rebalance
+        // Later on, new submissions and lost-and-reassigned connectors and tasks will be added to these assignments,
+        // and load-balancing revocations will be removed from them.
+        List<WorkerLoad> nextWorkerAssignment = workerLoads(memberAssignments);
+        removeAll(nextWorkerAssignment, deletedAndRevoked);
+        removeAll(nextWorkerAssignment, duplicatedAndRevoked);
 
-        handleLostAssignments(lostAssignments, newSubmissions, completeWorkerAssignment);
+        // Collect the lost assignments that are ready to be reassigned because the workers that were
+        // originally responsible for them appear to have left the cluster instead of rejoining within
+        // the scheduled rebalance delay. These assignments will be re-allocated to the existing workers
+        // in the cluster later on
+        ConnectorsAndTasks.Builder lostAssignmentsToReassignBuilder = new ConnectorsAndTasks.Builder();
+        handleLostAssignments(lostAssignments, lostAssignmentsToReassignBuilder, nextWorkerAssignment);
+        ConnectorsAndTasks lostAssignmentsToReassign = lostAssignmentsToReassignBuilder.build();
 
         // Do not revoke resources for re-assignment while a delayed rebalance is active
         if (delay == 0) {
-            Map<String, ConnectorsAndTasks> toExplicitlyRevoke =
-                    performTaskRevocation(activeAssignments, currentWorkerAssignment);
+            Map<String, ConnectorsAndTasks> loadBalancingRevocations =
+                    performLoadBalancingRevocations(configured, nextWorkerAssignment);
 
             // If this round and the previous round involved revocation, we will calculate a delay for
             // the next round when revoking rebalance would be allowed. Note that delay could be 0, in which
             // case we would always revoke.
-            if (revokedInPrevious && !toExplicitlyRevoke.isEmpty()) {
+            if (revokedInPrevious && !loadBalancingRevocations.isEmpty()) {
                 numSuccessiveRevokingRebalances++; // Should we consider overflow for this?
                 log.debug("Consecutive revoking rebalances observed. Computing delay and next scheduled rebalance.");
                 delay = (int) consecutiveRevokingRebalancesBackoff.backoff(numSuccessiveRevokingRebalances);
@@ -311,12 +306,18 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                             delay, scheduledRebalance);
                 } else {
                     log.debug("Revoking assignments immediately since scheduled.rebalance.max.delay.ms is set to 0");
-                    revoke(toRevoke, toExplicitlyRevoke);
+                    addAll(toRevoke, loadBalancingRevocations);
+                    // Remove all newly-revoked connectors and tasks from the next assignment, both to
+                    // ensure that they are not included in the assignments during this round, and to produce
+                    // an accurate allocation of all newly-created and lost-and-reassigned connectors and tasks
+                    // that will have to be distributed across the cluster during this round
+                    removeAll(nextWorkerAssignment, loadBalancingRevocations);
                 }
-            } else if (!toExplicitlyRevoke.isEmpty()) {
+            } else if (!loadBalancingRevocations.isEmpty()) {
                 // We had a revocation in this round but not in the previous round. Let's store that state.
                 log.debug("Performing allocation-balancing revocation immediately as no revocations took place during the previous rebalance");
-                revoke(toRevoke, toExplicitlyRevoke);
+                addAll(toRevoke, loadBalancingRevocations);
+                removeAll(nextWorkerAssignment, loadBalancingRevocations);
                 revokedInPrevious = true;
             } else if (revokedInPrevious) {
                 // No revocations in this round but the previous round had one. Probably the workers
@@ -334,49 +335,56 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
             revokedInPrevious = false;
         }
 
-        assignConnectors(completeWorkerAssignment, newSubmissions.connectors());
-        assignTasks(completeWorkerAssignment, newSubmissions.tasks());
-        log.debug("Current complete assignments: {}", currentWorkerAssignment);
-        log.debug("New complete assignments: {}", completeWorkerAssignment);
+        // The complete set of connectors and tasks that should be newly-assigned during this round
+        ConnectorsAndTasks toAssign = new ConnectorsAndTasks.Builder()
+                .addConnectors(created.connectors())
+                .addTasks(created.tasks())
+                .addConnectors(lostAssignmentsToReassign.connectors())
+                .addTasks(lostAssignmentsToReassign.tasks())
+                .build();
+
+        assignConnectors(nextWorkerAssignment, toAssign.connectors());
+        assignTasks(nextWorkerAssignment, toAssign.tasks());
+
+        Map<String, Collection<String>> nextConnectorAssignments = nextWorkerAssignment.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::connectors
+                ));
+        Map<String, Collection<ConnectorTaskId>> nextTaskAssignments = nextWorkerAssignment.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::tasks
+                ));
 
         Map<String, Collection<String>> currentConnectorAssignments =
                 currentWorkerAssignment.stream().collect(Collectors.toMap(WorkerLoad::worker, WorkerLoad::connectors));
         Map<String, Collection<ConnectorTaskId>> currentTaskAssignments =
                 currentWorkerAssignment.stream().collect(Collectors.toMap(WorkerLoad::worker, WorkerLoad::tasks));
         Map<String, Collection<String>> incrementalConnectorAssignments =
-                diff(connectorAssignments, currentConnectorAssignments);
+                diff(nextConnectorAssignments, currentConnectorAssignments);
         Map<String, Collection<ConnectorTaskId>> incrementalTaskAssignments =
-                diff(taskAssignments, currentTaskAssignments);
+                diff(nextTaskAssignments, currentTaskAssignments);
 
-        previousAssignment = computePreviousAssignment(toRevoke, connectorAssignments, taskAssignments, lostAssignments);
+        Map<String, ConnectorsAndTasks> revoked = buildAll(toRevoke);
+
+        previousAssignment = computePreviousAssignment(revoked, nextConnectorAssignments, nextTaskAssignments, lostAssignments);
         previousGenerationId = currentGenerationId;
         previousMembers = memberAssignments.keySet();
 
         log.debug("Incremental connector assignments: {}", incrementalConnectorAssignments);
         log.debug("Incremental task assignments: {}", incrementalTaskAssignments);
 
-        Map<String, Collection<String>> revokedConnectors = transformValues(toRevoke, ConnectorsAndTasks::connectors);
-        Map<String, Collection<ConnectorTaskId>> revokedTasks = transformValues(toRevoke, ConnectorsAndTasks::tasks);
+        Map<String, Collection<String>> revokedConnectors = transformValues(revoked, ConnectorsAndTasks::connectors);
+        Map<String, Collection<ConnectorTaskId>> revokedTasks = transformValues(revoked, ConnectorsAndTasks::tasks);
 
         return new ClusterAssignment(
                 incrementalConnectorAssignments,
                 incrementalTaskAssignments,
                 revokedConnectors,
                 revokedTasks,
-                diff(connectorAssignments, revokedConnectors),
-                diff(taskAssignments, revokedTasks)
-        );
-    }
-
-    private void revoke(Map<String, ConnectorsAndTasks> toRevoke, Map<String, ConnectorsAndTasks> toExplicitlyRevoke) {
-        toExplicitlyRevoke.forEach(
-                (worker, assignment) -> {
-                    ConnectorsAndTasks existing = toRevoke.computeIfAbsent(
-                            worker,
-                            v -> new ConnectorsAndTasks.Builder().build());
-                    existing.connectors().addAll(assignment.connectors());
-                    existing.tasks().addAll(assignment.tasks());
-                }
+                diff(nextConnectorAssignments, revokedConnectors),
+                diff(nextTaskAssignments, revokedTasks)
         );
     }
 
@@ -493,7 +501,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
     // visible for testing
     protected void handleLostAssignments(ConnectorsAndTasks lostAssignments,
-                                         ConnectorsAndTasks newSubmissions,
+                                         ConnectorsAndTasks.Builder lostAssignmentsToReassign,
                                          List<WorkerLoad> completeWorkerAssignment) {
         // There are no lost assignments and there have been no successive revoking rebalances
         if (lostAssignments.isEmpty() && !revokedInPrevious) {
@@ -513,8 +521,8 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                     + "missing assignments that the leader is detecting are probably due to some "
                     + "workers failing to receive the new assignments in the previous rebalance. "
                     + "Will reassign missing tasks as new tasks");
-            newSubmissions.connectors().addAll(lostAssignments.connectors());
-            newSubmissions.tasks().addAll(lostAssignments.tasks());
+            lostAssignmentsToReassign.addConnectors(lostAssignments.connectors());
+            lostAssignmentsToReassign.addTasks(lostAssignments.tasks());
             return;
         }
 
@@ -551,8 +559,8 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                 }
             } else {
                 log.debug("No single candidate worker was found to assign lost tasks. Treating lost tasks as new tasks");
-                newSubmissions.connectors().addAll(lostAssignments.connectors());
-                newSubmissions.tasks().addAll(lostAssignments.tasks());
+                lostAssignmentsToReassign.addConnectors(lostAssignments.connectors());
+                lostAssignmentsToReassign.addTasks(lostAssignments.tasks());
             }
             resetDelay();
             // Resetting the flag as now we can permit successive revoking rebalances.
@@ -602,89 +610,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                 .map(activeWorkers::get)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Task revocation is based on a rough estimation of the lower average number of tasks before
-     * and after new workers join the group. If no new workers join, no revocation takes place.
-     * Based on this estimation, tasks are revoked until the new floor average is reached for
-     * each existing worker. The revoked tasks, once assigned to the new workers will maintain
-     * a balanced load among the group.
-     *
-     * @param activeAssignments
-     * @param completeWorkerAssignment
-     * @return
-     */
-    private Map<String, ConnectorsAndTasks> performTaskRevocation(ConnectorsAndTasks activeAssignments,
-                                                                  Collection<WorkerLoad> completeWorkerAssignment) {
-        int totalActiveConnectorsNum = activeAssignments.connectors().size();
-        int totalActiveTasksNum = activeAssignments.tasks().size();
-        Collection<WorkerLoad> existingWorkers = completeWorkerAssignment.stream()
-                .filter(wl -> wl.size() > 0)
-                .collect(Collectors.toList());
-        int existingWorkersNum = existingWorkers.size();
-        int totalWorkersNum = completeWorkerAssignment.size();
-        int newWorkersNum = totalWorkersNum - existingWorkersNum;
-
-        if (log.isDebugEnabled()) {
-            completeWorkerAssignment.forEach(wl -> log.debug(
-                    "Per worker current load size; worker: {} connectors: {} tasks: {}",
-                    wl.worker(), wl.connectorsSize(), wl.tasksSize()));
-        }
-
-        Map<String, ConnectorsAndTasks> revoking = new HashMap<>();
-        // If there are no new workers, or no existing workers to revoke tasks from return early
-        // after logging the status
-        if (!(newWorkersNum > 0 && existingWorkersNum > 0)) {
-            log.debug("No task revocation required; workers with existing load: {} workers with "
-                    + "no load {} total workers {}",
-                    existingWorkersNum, newWorkersNum, totalWorkersNum);
-            // This is intentionally empty but mutable, because the map is used to include deleted
-            // connectors and tasks as well
-            return revoking;
-        }
-
-        log.debug("Task revocation is required; workers with existing load: {} workers with "
-                + "no load {} total workers {}",
-                existingWorkersNum, newWorkersNum, totalWorkersNum);
-
-        // We have at least one worker assignment (the leader itself) so totalWorkersNum can't be 0
-        log.debug("Previous rounded down (floor) average number of connectors per worker {}", totalActiveConnectorsNum / existingWorkersNum);
-        int floorConnectors = totalActiveConnectorsNum / totalWorkersNum;
-        int ceilConnectors = floorConnectors + ((totalActiveConnectorsNum % totalWorkersNum == 0) ? 0 : 1);
-        log.debug("New average number of connectors per worker rounded down (floor) {} and rounded up (ceil) {}", floorConnectors, ceilConnectors);
-
-
-        log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);
-        int floorTasks = totalActiveTasksNum / totalWorkersNum;
-        int ceilTasks = floorTasks + ((totalActiveTasksNum % totalWorkersNum == 0) ? 0 : 1);
-        log.debug("New average number of tasks per worker rounded down (floor) {} and rounded up (ceil) {}", floorTasks, ceilTasks);
-        int numToRevoke;
-
-        for (WorkerLoad existing : existingWorkers) {
-            Iterator<String> connectors = existing.connectors().iterator();
-            numToRevoke = existing.connectorsSize() - ceilConnectors;
-            for (int i = existing.connectorsSize(); i > floorConnectors && numToRevoke > 0; --i, --numToRevoke) {
-                ConnectorsAndTasks resources = revoking.computeIfAbsent(
-                    existing.worker(),
-                    w -> new ConnectorsAndTasks.Builder().build());
-                resources.connectors().add(connectors.next());
-            }
-        }
-
-        for (WorkerLoad existing : existingWorkers) {
-            Iterator<ConnectorTaskId> tasks = existing.tasks().iterator();
-            numToRevoke = existing.tasksSize() - ceilTasks;
-            log.debug("Tasks on worker {} is higher than ceiling, so revoking {} tasks", existing, numToRevoke);
-            for (int i = existing.tasksSize(); i > floorTasks && numToRevoke > 0; --i, --numToRevoke) {
-                ConnectorsAndTasks resources = revoking.computeIfAbsent(
-                    existing.worker(),
-                    w -> new ConnectorsAndTasks.Builder().build());
-                resources.tasks().add(tasks.next());
-            }
-        }
-
-        return revoking;
     }
 
     private Map<String, ExtendedAssignment> fillAssignments(Collection<String> members, short error,
@@ -751,6 +676,146 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                 ConnectUtils.combineCollections(memberAssignments.values(), ConnectorsAndTasks::connectors),
                 ConnectUtils.combineCollections(memberAssignments.values(), ConnectorsAndTasks::tasks)
         ).build();
+    }
+
+    /**
+     * Revoke connectors and tasks from each worker in the cluster until no worker is running more than it would be if:
+     * <ul>
+     *     <li>The allocation of connectors and tasks across the cluster were as balanced as possible (i.e., the difference in allocation size between any two workers is at most one)</li>
+     *     <li>Any workers that left the group within the scheduled rebalance delay permanently left the group</li>
+     *     <li>All currently-configured connectors and tasks were allocated (including instances that may be revoked in this round because they are duplicated across workers)</li>
+     * </ul>
+     * @param configured the set of configured connectors and tasks across the entire cluster
+     * @param workers the workers in the cluster, whose assignments should not include any deleted or duplicated connectors or tasks
+     *                that are already due to be revoked from the worker in this rebalance
+     * @return which connectors and tasks should be revoked from which workers; never null, but may be empty
+     * if no load-balancing revocations are necessary or possible
+     */
+    private Map<String, ConnectorsAndTasks> performLoadBalancingRevocations(
+            ConnectorsAndTasks configured,
+            Collection<WorkerLoad> workers
+    ) {
+        if (log.isTraceEnabled()) {
+            workers.forEach(wl -> log.trace(
+                    "Per worker current load size; worker: {} connectors: {} tasks: {}",
+                    wl.worker(), wl.connectorsSize(), wl.tasksSize()));
+        }
+
+        if (workers.stream().allMatch(WorkerLoad::isEmpty)) {
+            log.trace("No load-balancing revocations required; all workers are either new "
+                    + "or will have all currently-assigned connectors and tasks revoked during this round"
+            );
+            return Collections.emptyMap();
+        }
+        if (configured.isEmpty()) {
+            log.trace("No load-balancing revocations required; no connectors are currently configured on this cluster");
+            return Collections.emptyMap();
+        }
+
+        Map<String, ConnectorsAndTasks.Builder> result = new HashMap<>();
+
+        Map<String, Set<String>> connectorRevocations = loadBalancingRevocations(
+                "connector",
+                configured.connectors().size(),
+                workers,
+                WorkerLoad::connectors
+        );
+        Map<String, Set<ConnectorTaskId>> taskRevocations = loadBalancingRevocations(
+                "task",
+                configured.tasks().size(),
+                workers,
+                WorkerLoad::tasks
+        );
+
+        connectorRevocations.forEach((worker, revoked) ->
+                result.computeIfAbsent(worker, w -> new ConnectorsAndTasks.Builder()).addConnectors(revoked)
+        );
+        taskRevocations.forEach((worker, revoked) ->
+                result.computeIfAbsent(worker, w -> new ConnectorsAndTasks.Builder()).addTasks(revoked)
+        );
+
+        return buildAll(result);
+    }
+
+    private <E> Map<String, Set<E>> loadBalancingRevocations(
+            String allocatedResourceName,
+            int totalToAllocate,
+            Collection<WorkerLoad> workers,
+            Function<WorkerLoad, Collection<E>> workerAllocation
+    ) {
+        int totalWorkers = workers.size();
+        // The minimum instances of this resource that should be assigned to each worker
+        int minAllocatedPerWorker = totalToAllocate / totalWorkers;
+        // How many workers are going to have to be allocated exactly one extra instance
+        // (since the total number to allocate may not be a perfect multiple of the number of workers)
+        int extrasToAllocate = totalToAllocate % totalWorkers;
+        // Useful function to determine exactly how many instances of the resource a given worker is currently allocated
+        Function<WorkerLoad, Integer> workerAllocationSize = workerAllocation.andThen(Collection::size);
+
+        long workersAllocatedMinimum = workers.stream()
+                .map(workerAllocationSize)
+                .filter(n -> n == minAllocatedPerWorker)
+                .count();
+        long workersAllocatedSingleExtra = workers.stream()
+                .map(workerAllocationSize)
+                .filter(n -> n == minAllocatedPerWorker + 1)
+                .count();
+        if (workersAllocatedSingleExtra == extrasToAllocate
+                && workersAllocatedMinimum + workersAllocatedSingleExtra == totalWorkers) {
+            log.trace(
+                    "No load-balancing {} revocations required; the current allocations, when combined with any newly-created {}, should be balanced",
+                    allocatedResourceName,
+                    allocatedResourceName
+            );
+            return Collections.emptyMap();
+        }
+
+        Map<String, Set<E>> result = new HashMap<>();
+        // How many workers we've allocated a single extra resource instance to
+        int allocatedExtras = 0;
+        for (WorkerLoad worker : workers) {
+            int currentAllocationSizeForWorker = workerAllocationSize.apply(worker);
+            if (currentAllocationSizeForWorker <= minAllocatedPerWorker) {
+                // This worker isn't allocated more than the minimum; no need to revoke anything
+                continue;
+            }
+            int maxAllocationForWorker;
+            if (allocatedExtras < extrasToAllocate) {
+                // We'll allocate one of the extra resource instances to this worker
+                allocatedExtras++;
+                if (currentAllocationSizeForWorker == minAllocatedPerWorker + 1) {
+                    // If the worker's running exactly one more than the minimum, and we're allowed to
+                    // allocate an extra to it, there's no need to revoke anything
+                    continue;
+                }
+                maxAllocationForWorker = minAllocatedPerWorker + 1;
+            } else {
+                maxAllocationForWorker = minAllocatedPerWorker;
+            }
+
+            Set<E> revokedFromWorker = new LinkedHashSet<>();
+            result.put(worker.worker(), revokedFromWorker);
+
+            Iterator<E> currentWorkerAllocation = workerAllocation.apply(worker).iterator();
+            // Revoke resources from the worker until it isn't allocated any more than it should be
+            for (int numRevoked = 0; currentAllocationSizeForWorker - numRevoked > maxAllocationForWorker; numRevoked++) {
+                if (!currentWorkerAllocation.hasNext()) {
+                    // Should never happen, but better to log a warning and move on than die and fail the whole rebalance if it does
+                    log.warn(
+                            "Unexpectedly ran out of {}s to revoke from worker {} while performing load-balancing revocations; " +
+                                    "worker appears to still be allocated {} instances, which is more than the intended allocation of {}",
+                            allocatedResourceName,
+                            worker.worker(),
+                            workerAllocationSize.apply(worker),
+                            maxAllocationForWorker
+                    );
+                    break;
+                }
+                E revocation = currentWorkerAllocation.next();
+                revokedFromWorker.add(revocation);
+            }
+        }
+        return result;
     }
 
     private int calculateDelay(long now) {
@@ -821,7 +886,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
     private static List<WorkerLoad> workerAssignment(Map<String, ConnectorsAndTasks> memberAssignments,
                                                      ConnectorsAndTasks toExclude) {
         ConnectorsAndTasks ignore = new ConnectorsAndTasks.Builder()
-                .with(new HashSet<>(toExclude.connectors()), new HashSet<>(toExclude.tasks()))
+                .with(toExclude.connectors(), toExclude.tasks())
                 .build();
 
         return memberAssignments.entrySet().stream()
@@ -834,6 +899,43 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                                 .collect(Collectors.toList())
                         ).build()
                 ).collect(Collectors.toList());
+    }
+
+    private static void addAll(Map<String, ConnectorsAndTasks.Builder> base, Map<String, ConnectorsAndTasks> toAdd) {
+        toAdd.forEach((worker, assignment) -> base
+                .computeIfAbsent(worker, w -> new ConnectorsAndTasks.Builder())
+                .addConnectors(assignment.connectors())
+                .addTasks(assignment.tasks())
+        );
+    }
+
+    private static <K> Map<K, ConnectorsAndTasks> buildAll(Map<K, ConnectorsAndTasks.Builder> builders) {
+        return transformValues(builders, ConnectorsAndTasks.Builder::build);
+    }
+
+    private static List<WorkerLoad> workerLoads(Map<String, ConnectorsAndTasks> memberAssignments) {
+        return memberAssignments.entrySet().stream()
+                .map(e -> new WorkerLoad.Builder(e.getKey()).with(e.getValue().connectors(), e.getValue().tasks()).build())
+                .collect(Collectors.toList());
+    }
+
+    private static void removeAll(List<WorkerLoad> workerLoads, Map<String, ConnectorsAndTasks> toRemove) {
+        workerLoads.forEach(workerLoad -> {
+            String worker = workerLoad.worker();
+            ConnectorsAndTasks toRemoveFromWorker = toRemove.getOrDefault(worker, ConnectorsAndTasks.EMPTY);
+            workerLoad.connectors().removeAll(toRemoveFromWorker.connectors());
+            workerLoad.tasks().removeAll(toRemoveFromWorker.tasks());
+        });
+    }
+
+    private static Map<String, ConnectorsAndTasks> intersection(ConnectorsAndTasks connectorsAndTasks, Map<String, ConnectorsAndTasks> assignments) {
+        return transformValues(assignments, assignment -> {
+            Collection<String> connectors = new HashSet<>(assignment.connectors());
+            connectors.retainAll(connectorsAndTasks.connectors());
+            Collection<ConnectorTaskId> tasks = new HashSet<>(assignment.tasks());
+            tasks.retainAll(connectorsAndTasks.tasks());
+            return new ConnectorsAndTasks.Builder().with(connectors, tasks).build();
+        });
     }
 
     static class ClusterAssignment {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -37,9 +37,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import static org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember;
@@ -455,30 +457,31 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         }
 
         public static class Builder {
-            private Collection<String> withConnectors;
-            private Collection<ConnectorTaskId> withTasks;
+            private Set<String> withConnectors = new LinkedHashSet<>();
+            private Set<ConnectorTaskId> withTasks = new LinkedHashSet<>();
 
             public Builder() {
             }
 
-            public ConnectorsAndTasks.Builder withCopies(Collection<String> connectors,
-                                                         Collection<ConnectorTaskId> tasks) {
-                withConnectors = new ArrayList<>(connectors);
-                withTasks = new ArrayList<>(tasks);
+            public ConnectorsAndTasks.Builder with(Collection<String> connectors,
+                                                   Collection<ConnectorTaskId> tasks) {
+                withConnectors = new LinkedHashSet<>(connectors);
+                withTasks = new LinkedHashSet<>(tasks);
                 return this;
             }
 
-            public ConnectorsAndTasks.Builder with(Collection<String> connectors,
-                                                   Collection<ConnectorTaskId> tasks) {
-                withConnectors = new ArrayList<>(connectors);
-                withTasks = new ArrayList<>(tasks);
+            public ConnectorsAndTasks.Builder addConnectors(Collection<String> connectors) {
+                this.withConnectors.addAll(connectors);
+                return this;
+            }
+
+            public ConnectorsAndTasks.Builder addTasks(Collection<ConnectorTaskId> tasks) {
+                this.withTasks.addAll(tasks);
                 return this;
             }
 
             public ConnectorsAndTasks build() {
-                return new ConnectorsAndTasks(
-                        withConnectors != null ? withConnectors : new ArrayList<>(),
-                        withTasks != null ? withTasks : new ArrayList<>());
+                return new ConnectorsAndTasks(withConnectors, withTasks);
             }
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -110,7 +110,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // Third assignment after revocations
         performStandardRebalance();
-        assertTrue(assignor.delay > 0); // Sucessive revocation so delay should be non-zero
+        assertNoRevocations();
+        assertDelay(0);
         assertConnectorAllocations(1, 1);
         assertTaskAllocations(4, 4);
         assertBalancedAndCompleteAllocation();
@@ -124,6 +125,9 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testAssignmentsWhenWorkersJoinAfterRevocations()  {
+        // Customize assignor for this test case
+        time = new MockTime();
+        initAssignor();
 
         addNewConnector("connector3", 4);
         // First assignment with 1 worker and 3 connectors configured but not yet assigned
@@ -190,7 +194,6 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testImmediateRevocationsWhenMaxDelayIs0()  {
-
         // Customize assignor for this test case
         rebalanceDelay = 0;
         time = new MockTime();
@@ -220,11 +223,12 @@ public class IncrementalCooperativeAssignorTest {
         assertDelay(0);
         assertWorkers("worker1", "worker2", "worker3");
         assertConnectorAllocations(0, 1, 1);
-        assertTaskAllocations(2, 3, 3);
+        assertTaskAllocations(3, 3, 4);
 
         // Follow up rebalance post revocations
         performStandardRebalance();
         assertWorkers("worker1", "worker2", "worker3");
+        assertNoRevocations();
         assertConnectorAllocations(1, 1, 1);
         assertTaskAllocations(4, 4, 4);
         assertBalancedAndCompleteAllocation();
@@ -232,7 +236,7 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testSuccessiveRevocationsWhenMaxDelayIsEqualToExpBackOffInitialInterval() {
-
+        // Customize assignor for this test case
         rebalanceDelay = 1;
         initAssignor();
 
@@ -261,6 +265,72 @@ public class IncrementalCooperativeAssignorTest {
         assertWorkers("worker1", "worker2", "worker3");
         assertConnectorAllocations(0, 1, 2);
         assertTaskAllocations(3, 3, 6);
+    }
+
+    @Test
+    public void testWorkerJoiningDuringDelayedRebalance() {
+        // Customize assignor for this test case
+        time = new MockTime();
+        initAssignor();
+
+        addNewConnector("connector3", 4);
+        // First assignment with 1 worker and 3 connectors configured but not yet assigned
+        performStandardRebalance();
+        assertDelay(0);
+        assertWorkers("worker1");
+        assertConnectorAllocations(3);
+        assertTaskAllocations(12);
+        assertBalancedAndCompleteAllocation();
+
+        // Second assignment with a second worker joining and all connectors running on previous worker
+        // We should revoke.
+        addNewEmptyWorkers("worker2");
+        performStandardRebalance();
+        assertWorkers("worker1", "worker2");
+        assertConnectorAllocations(0, 2);
+        assertTaskAllocations(0, 6);
+
+        // Third assignment immediately after revocations, and a third worker joining.
+        // This is a successive revoking rebalance. We should not perform any revocations
+        // in this round, but can allocate the connectors and tasks revoked previously
+        addNewEmptyWorkers("worker3");
+        performStandardRebalance();
+        assertTrue(assignor.delay > 0);
+        assertWorkers("worker1", "worker2", "worker3");
+        assertNoRevocations();
+        assertConnectorAllocations(0, 1, 2);
+        assertTaskAllocations(3, 3, 6);
+
+        // Fourth assignment and a fourth worker joining
+        // while delayed rebalance is active. We should not revoke
+        time.sleep(assignor.delay / 2);
+        addNewEmptyWorkers("worker4");
+        performStandardRebalance();
+        assertTrue(assignor.delay > 0);
+        assertWorkers("worker1", "worker2", "worker3", "worker4");
+        assertNoRevocations();
+        assertConnectorAllocations(0, 0, 1, 2);
+        assertTaskAllocations(0, 3, 3, 6);
+
+        // Fifth assignment and a fifth worker joining
+        // after the delay has expired. We should perform load-balancing
+        // revocations
+        time.sleep(assignor.delay);
+        addNewEmptyWorkers("worker5");
+        performStandardRebalance();
+        assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5");
+        assertDelay(0);
+        assertConnectorAllocations(0, 0, 0, 1, 1);
+        assertTaskAllocations(0, 0, 2, 3, 3);
+
+        // Sixth and final rebalance, as a follow-up to the revocations in the previous round.
+        // Should allocate all previously-revoked connectors and tasks evenly across the cluster
+        performStandardRebalance();
+        assertDelay(0);
+        assertNoRevocations();
+        assertConnectorAllocations(0, 0, 1, 1, 1);
+        assertTaskAllocations(2, 2, 2, 3, 3);
+        assertBalancedAndCompleteAllocation();
     }
 
     @Test
@@ -353,12 +423,7 @@ public class IncrementalCooperativeAssignorTest {
         // should be revocations giving back the assignments to the reappearing worker
         performStandardRebalance();
         assertDelay(0);
-        assertConnectorAllocations(1, 1);
-        assertTaskAllocations(2, 4);
-
-        // Final follow up rebalance leading to balanced assignments
-        performStandardRebalance();
-        assertDelay(0);
+        assertNoRevocations();
         assertConnectorAllocations(1, 1);
         assertTaskAllocations(4, 4);
         assertBalancedAndCompleteAllocation();
@@ -366,10 +431,6 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testTaskAssignmentWhenLeaderLeavesPermanently() {
-        // Customize assignor for this test case
-        time = new MockTime();
-        initAssignor();
-
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         addNewEmptyWorkers("worker2", "worker3");
         performStandardRebalance();
@@ -402,10 +463,6 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testTaskAssignmentWhenLeaderBounces() {
-        // Customize assignor for this test case
-        time = new MockTime();
-        initAssignor();
-
         // First assignment with 3 workers and 2 connectors configured but not yet assigned
         addNewEmptyWorkers("worker2", "worker3");
         performStandardRebalance();
@@ -422,7 +479,6 @@ public class IncrementalCooperativeAssignorTest {
         // The fact that the leader bounces means that the assignor starts from a clean slate
         initAssignor();
 
-        // Capture needs to be reset to point to the new assignor
         performStandardRebalance();
         assertDelay(0);
         assertWorkers("worker2", "worker3");
@@ -442,7 +498,8 @@ public class IncrementalCooperativeAssignorTest {
 
         // Fourth assignment after revocations
         performStandardRebalance();
-        assertTrue(assignor.delay > 0); // Successive revoking rebalance. Should introduce a delay
+        assertDelay(0);
+        assertNoRevocations();
         assertConnectorAllocations(0, 1, 1);
         assertTaskAllocations(2, 3, 3);
         assertBalancedAndCompleteAllocation();
@@ -450,10 +507,6 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testTaskAssignmentWhenFirstAssignmentAttemptFails() {
-        // Customize assignor for this test case
-        time = new MockTime();
-        initAssignor();
-
         // First assignment with 2 workers and 2 connectors configured but not yet assigned
         addNewEmptyWorkers("worker2");
         performFailedRebalance();
@@ -668,11 +721,9 @@ public class IncrementalCooperativeAssignorTest {
         configuredAssignment.put("worker1", workerLoad("worker1", 2, 2, 4, 4));
         configuredAssignment.put("worker2", workerLoad("worker2", 4, 2, 8, 4));
 
-        ConnectorsAndTasks newSubmissions = new ConnectorsAndTasks.Builder().build();
-
         // No lost assignments
         assignor.handleLostAssignments(new ConnectorsAndTasks.Builder().build(),
-                newSubmissions,
+                new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -686,10 +737,10 @@ public class IncrementalCooperativeAssignorTest {
         String flakyWorker = "worker1";
         WorkerLoad lostLoad = configuredAssignment.remove(flakyWorker);
         ConnectorsAndTasks lostAssignments = new ConnectorsAndTasks.Builder()
-                .withCopies(lostLoad.connectors(), lostLoad.tasks()).build();
+                .with(lostLoad.connectors(), lostLoad.tasks()).build();
 
         // Lost assignments detected - No candidate worker has appeared yet (worker with no assignments)
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -704,7 +755,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // A new worker (probably returning worker) has joined
         configuredAssignment.put(flakyWorker, new WorkerLoad.Builder(flakyWorker).build());
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -717,7 +768,7 @@ public class IncrementalCooperativeAssignorTest {
         time.sleep(rebalanceDelay);
 
         // The new worker has still no assignments
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertTrue("Wrong assignment of lost connectors",
@@ -750,11 +801,9 @@ public class IncrementalCooperativeAssignorTest {
         configuredAssignment.put("worker1", workerLoad("worker1", 2, 2, 4, 4));
         configuredAssignment.put("worker2", workerLoad("worker2", 4, 2, 8, 4));
 
-        ConnectorsAndTasks newSubmissions = new ConnectorsAndTasks.Builder().build();
-
         // No lost assignments
         assignor.handleLostAssignments(new ConnectorsAndTasks.Builder().build(),
-                newSubmissions,
+                new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -768,10 +817,10 @@ public class IncrementalCooperativeAssignorTest {
         String removedWorker = "worker1";
         WorkerLoad lostLoad = configuredAssignment.remove(removedWorker);
         ConnectorsAndTasks lostAssignments = new ConnectorsAndTasks.Builder()
-                .withCopies(lostLoad.connectors(), lostLoad.tasks()).build();
+                .with(lostLoad.connectors(), lostLoad.tasks()).build();
 
         // Lost assignments detected - No candidate worker has appeared yet (worker with no assignments)
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -785,7 +834,7 @@ public class IncrementalCooperativeAssignorTest {
         rebalanceDelay /= 2;
 
         // No new worker has joined
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -796,13 +845,14 @@ public class IncrementalCooperativeAssignorTest {
 
         time.sleep(rebalanceDelay);
 
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        ConnectorsAndTasks.Builder lostAssignmentsToReassign = new ConnectorsAndTasks.Builder();
+        assignor.handleLostAssignments(lostAssignments, lostAssignmentsToReassign,
                 new ArrayList<>(configuredAssignment.values()));
 
         assertTrue("Wrong assignment of lost connectors",
-                newSubmissions.connectors().containsAll(lostAssignments.connectors()));
+                lostAssignmentsToReassign.build().connectors().containsAll(lostAssignments.connectors()));
         assertTrue("Wrong assignment of lost tasks",
-                newSubmissions.tasks().containsAll(lostAssignments.tasks()));
+                lostAssignmentsToReassign.build().tasks().containsAll(lostAssignments.tasks()));
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
@@ -825,11 +875,9 @@ public class IncrementalCooperativeAssignorTest {
         configuredAssignment.put("worker1", workerLoad("worker1", 2, 2, 4, 4));
         configuredAssignment.put("worker2", workerLoad("worker2", 4, 2, 8, 4));
 
-        ConnectorsAndTasks newSubmissions = new ConnectorsAndTasks.Builder().build();
-
         // No lost assignments
         assignor.handleLostAssignments(new ConnectorsAndTasks.Builder().build(),
-                newSubmissions,
+                new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -843,13 +891,13 @@ public class IncrementalCooperativeAssignorTest {
         String flakyWorker = "worker1";
         WorkerLoad lostLoad = configuredAssignment.remove(flakyWorker);
         ConnectorsAndTasks lostAssignments = new ConnectorsAndTasks.Builder()
-                .withCopies(lostLoad.connectors(), lostLoad.tasks()).build();
+                .with(lostLoad.connectors(), lostLoad.tasks()).build();
 
         String newWorker = "worker3";
         configuredAssignment.put(newWorker, new WorkerLoad.Builder(newWorker).build());
 
         // Lost assignments detected - A new worker also has joined that is not the returning worker
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -864,7 +912,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // Now two new workers have joined
         configuredAssignment.put(flakyWorker, new WorkerLoad.Builder(flakyWorker).build());
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         Set<String> expectedWorkers = new HashSet<>();
@@ -883,7 +931,7 @@ public class IncrementalCooperativeAssignorTest {
         configuredAssignment.put(newWorker, workerLoad(newWorker, 8, 2, 12, 4));
         // we don't reflect these new assignments in memberConfigs currently because they are not
         // used in handleLostAssignments method
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         // both the newWorkers would need to be considered for re assignment of connectors and tasks
@@ -923,11 +971,9 @@ public class IncrementalCooperativeAssignorTest {
         configuredAssignment.put("worker1", workerLoad("worker1", 2, 2, 4, 4));
         configuredAssignment.put("worker2", workerLoad("worker2", 4, 2, 8, 4));
 
-        ConnectorsAndTasks newSubmissions = new ConnectorsAndTasks.Builder().build();
-
         // No lost assignments
         assignor.handleLostAssignments(new ConnectorsAndTasks.Builder().build(),
-                newSubmissions,
+                new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -941,10 +987,10 @@ public class IncrementalCooperativeAssignorTest {
         String veryFlakyWorker = "worker1";
         WorkerLoad lostLoad = configuredAssignment.remove(veryFlakyWorker);
         ConnectorsAndTasks lostAssignments = new ConnectorsAndTasks.Builder()
-                .withCopies(lostLoad.connectors(), lostLoad.tasks()).build();
+                .with(lostLoad.connectors(), lostLoad.tasks()).build();
 
         // Lost assignments detected - No candidate worker has appeared yet (worker with no assignments)
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -959,7 +1005,7 @@ public class IncrementalCooperativeAssignorTest {
 
         // A new worker (probably returning worker) has joined
         configuredAssignment.put(veryFlakyWorker, new WorkerLoad.Builder(veryFlakyWorker).build());
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        assignor.handleLostAssignments(lostAssignments, new ConnectorsAndTasks.Builder(),
                 new ArrayList<>(configuredAssignment.values()));
 
         assertEquals("Wrong set of workers for reassignments",
@@ -973,13 +1019,14 @@ public class IncrementalCooperativeAssignorTest {
 
         // The returning worker leaves permanently after joining briefly during the delay
         configuredAssignment.remove(veryFlakyWorker);
-        assignor.handleLostAssignments(lostAssignments, newSubmissions,
+        ConnectorsAndTasks.Builder lostAssignmentsToReassign = new ConnectorsAndTasks.Builder();
+        assignor.handleLostAssignments(lostAssignments, lostAssignmentsToReassign,
                 new ArrayList<>(configuredAssignment.values()));
 
         assertTrue("Wrong assignment of lost connectors",
-                newSubmissions.connectors().containsAll(lostAssignments.connectors()));
+                lostAssignmentsToReassign.build().connectors().containsAll(lostAssignments.connectors()));
         assertTrue("Wrong assignment of lost tasks",
-                newSubmissions.tasks().containsAll(lostAssignments.tasks()));
+                lostAssignmentsToReassign.build().tasks().containsAll(lostAssignments.tasks()));
         assertEquals("Wrong set of workers for reassignments",
                 Collections.emptySet(),
                 assignor.candidateWorkersForReassignment);
@@ -1008,12 +1055,7 @@ public class IncrementalCooperativeAssignorTest {
         // Third assignment after revocations
         performStandardRebalance();
         assertDelay(0);
-        assertConnectorAllocations(1, 1);
-        assertTaskAllocations(2, 4);
-
-        // fourth rebalance after revocations
-        performStandardRebalance();
-        assertDelay(0);
+        assertNoRevocations();
         assertConnectorAllocations(1, 1);
         assertTaskAllocations(4, 4);
         assertBalancedAndCompleteAllocation();
@@ -1026,6 +1068,10 @@ public class IncrementalCooperativeAssignorTest {
 
     @Test
     public void testDuplicatedAssignmentHandleWhenTheDuplicatedAssignmentsDeleted() {
+        // Customize assignor for this test case
+        time = new MockTime();
+        initAssignor();
+
         // First assignment with 1 worker and 2 connectors configured but not yet assigned
         performStandardRebalance();
         assertDelay(0);
@@ -1043,17 +1089,12 @@ public class IncrementalCooperativeAssignorTest {
         assertDelay(0);
         assertWorkers("worker1", "worker2");
         assertConnectorAllocations(0, 1);
-        assertTaskAllocations(0, 4);
+        assertTaskAllocations(0, 2);
 
         // Third assignment after revocations
         performStandardRebalance();
         assertDelay(0);
-        assertConnectorAllocations(0, 1);
-        assertTaskAllocations(0, 2);
-
-        // fourth rebalance after revocations
-        performStandardRebalance();
-        assertTrue(assignor.delay > 0);
+        assertNoRevocations();
         assertConnectorAllocations(0, 1);
         assertTaskAllocations(2, 2);
         assertBalancedAndCompleteAllocation();
@@ -1182,7 +1223,11 @@ public class IncrementalCooperativeAssignorTest {
         generationId++;
         int lastCompletedGenerationId = generationMismatch ? generationId - 2 : generationId - 1;
         try {
-            Map<String, ConnectorsAndTasks> memberAssignmentsCopy = new HashMap<>(memberAssignments);
+            Map<String, ConnectorsAndTasks> memberAssignmentsCopy = memberAssignments.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> new ConnectorsAndTasks.Builder().with(e.getValue().connectors(), e.getValue().tasks()).build()
+                    ));
             returnedAssignments = assignor.performTaskAssignment(configState(), lastCompletedGenerationId, generationId, memberAssignmentsCopy);
         } catch (RuntimeException e) {
             if (assignmentFailure) {
@@ -1204,7 +1249,7 @@ public class IncrementalCooperativeAssignorTest {
     }
 
     private void addNewWorker(String worker, List<String> connectors, List<ConnectorTaskId> tasks) {
-        ConnectorsAndTasks assignment = new ConnectorsAndTasks.Builder().withCopies(connectors, tasks).build();
+        ConnectorsAndTasks assignment = new ConnectorsAndTasks.Builder().with(connectors, tasks).build();
         assertNull(
                 "Worker " + worker + " already exists",
                 memberAssignments.put(worker, assignment)
@@ -1296,14 +1341,14 @@ public class IncrementalCooperativeAssignorTest {
             assertEquals(
                     "Complete connector assignment for worker " + worker + " does not match expectations " +
                             "based on prior assignment and new revocations and assignments",
-                    workerAssignment.connectors(),
-                    returnedAssignments.allAssignedConnectors().get(worker)
+                    new HashSet<>(workerAssignment.connectors()),
+                    new HashSet<>(returnedAssignments.allAssignedConnectors().get(worker))
             );
             assertEquals(
                     "Complete task assignment for worker " + worker + " does not match expectations " +
                             "based on prior assignment and new revocations and assignments",
-                    workerAssignment.tasks(),
-                    returnedAssignments.allAssignedTasks().get(worker)
+                    new HashSet<>(workerAssignment.tasks()),
+                    new HashSet<>(returnedAssignments.allAssignedTasks().get(worker))
             );
         });
     }
@@ -1378,6 +1423,23 @@ public class IncrementalCooperativeAssignorTest {
                 .map(Collection::size)
                 .sorted()
                 .collect(Collectors.toList());
+    }
+
+    private void assertNoRevocations() {
+        returnedAssignments.newlyRevokedConnectors().forEach((worker, revocations) ->
+                assertEquals(
+                        "Expected no revocations to take place during this round, but connector revocations were issued for worker " + worker,
+                        Collections.emptySet(),
+                        new HashSet<>(revocations)
+                )
+        );
+        returnedAssignments.newlyRevokedTasks().forEach((worker, revocations) ->
+                assertEquals(
+                        "Expected no revocations to take place during this round, but task revocations were issued for worker " + worker,
+                        Collections.emptySet(),
+                        new HashSet<>(revocations)
+                )
+        );
     }
 
     private void assertDelay(int expectedDelay) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
@@ -517,13 +517,13 @@ public class WorkerCoordinatorIncrementalTest {
         leaderAssignment = deserializeAssignment(result, leaderId);
         assertAssignment(leaderId, offset,
                 Collections.emptyList(), 0,
-                Collections.emptyList(), 1,
+                Collections.emptyList(), 0,
                 leaderAssignment);
 
         memberAssignment = deserializeAssignment(result, memberId);
         assertAssignment(leaderId, offset,
                 Collections.emptyList(), 0,
-                Collections.emptyList(), 1,
+                Collections.emptyList(), 0,
                 memberAssignment);
 
         anotherMemberAssignment = deserializeAssignment(result, anotherMemberId);


### PR DESCRIPTION
Follow-up as discussed on the [open PR](https://github.com/apache/kafka/pull/12561) for KAFKA-12495, which ports some changes from https://github.com/apache/kafka/pull/12019 onto that PR branch.

These changes should fix some issues with load-balancing revocations and assignment of new and lost connectors and tasks. The primary differences are when load-balancing revocations take place (a number of currently-missed cases are added), when lost assignments are reassigned, and how load-balancing revocations are calculated.

One result is that a number of unnecessary follow-up rebalances are skipped since a balanced allocation can be achieved sooner, and potential regressions introduced in the upstream PR for KAFKA-12495 are avoided as a result.

Another result is that resizing connectors should no longer lead to unbalanced allocations across the cluster during rebalance.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
